### PR TITLE
More rules docs patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,21 +57,21 @@ Join the [Discord](https://discord.gg/5QQHmZQavP) for development updates and bu
 
 ## Supported rulesets
 
-- __Riichi__: The classic riichi ruleset, now with an assortment of mods to pick and choose at your liking.
-- __Sanma__: Three-player Riichi.
+- [__Riichi__](documentation/riichi.md): The classic riichi ruleset, now with an assortment of mods to pick and choose at your liking.
+- [__Sanma__](documentation/sanma.md): Three-player Riichi.
 - __Space Mahjong__: Riichi, but sequences can wrap (891, 912), and you can make sequences from winds and dragons. In addition, you can chii from any direction, and form open kokushi (3 han).
 - __Cosmic Riichi__: A Space Mahjong variant with mixed triplets, more yaku, and more calls.
-- __Galaxy Mahjong__: Riichi, but one of each tile is replaced with a blue galaxy tile that acts as a wildcard of its number. Galaxy winds are wind wildcards, and galaxy dragons are dragon wildcards.
-- __Kansai Sanma__: Sanma, but you draw until the last visible dora indicator. In addition, all fives are akadora, fu is fixed at 30, there is no tsumo loss, and scores are rounded to the nearest 1000. Flowers act as nukidora in place of north winds, which are now yakuhai. Exhaustive draws in south round always result in a repeat regardless of who's tenpai.
-- __Chinitsu__: Two-player variant where the only tiles are bamboo tiles. Try not to chombo!
+- [__Galaxy Mahjong__](documentation/galaxy.md): Riichi, but one of each tile is replaced with a blue galaxy tile that acts as a wildcard of its number. Galaxy winds are wind wildcards, and galaxy dragons are dragon wildcards.
+- [__Kansai Sanma__](documentation/kansai.md): Sanma, but you draw until the last visible dora indicator. In addition, all fives are akadora, fu is fixed at 30, there is no tsumo loss, and scores are rounded to the nearest 1000. Flowers act as nukidora in place of north winds, which are now yakuhai. Exhaustive draws in south round always result in a repeat regardless of who's tenpai.
+- [__Chinitsu__](documentation/chinitsu_challenge.md): Two-player variant where the only tiles are bamboo tiles. Try not to chombo!
 - __Minefield__: Two-player variant where you start with 34 tiles to make a mangan+ hand, and your remaining tiles are your discards.
 - __Sakicards v1.3__: Riichi, but everyone gets a different Saki power, which changes the game quite a bit. Some give you bonus han every time you use your power. Some let you recover dead discards. Some let you swap tiles around the entire board, including the dora indicator.
-- __Hong Kong__: Hong Kong Old Style mahjong. Three point minimum, everyone pays for a win, and win instantly if you have seven flowers.
-- __Sichuan Bloody__: Sichuan Bloody mahjong. Trade tiles, void a suit, and play until three players win (bloody end rules).
+- [__Hong Kong__](documentation/hk.md): Hong Kong Old Style mahjong. Three point minimum, everyone pays for a win, and win instantly if you have seven flowers.
+- [__Sichuan Bloody__](documentation/sichuan.md): Sichuan Bloody mahjong. Trade tiles, void a suit, and play until three players win (bloody end rules).
 - __MCR__: Mahjong Competition Rules. Has a scoring system of a different kind of complexity than Riichi.
 - __Taiwanese__: 16-tile mahjong with riichi mechanics.
-- __Bloody 30-Faan Jokers__: Bloody end rules mahjong, with Vietnamese jokers, and somehow more yaku than MCR.
-- __American (2024 NMJL)__: American mahjong. Assemble hands with jokers, and declare other players' hands dead.
+- [__Bloody 30-Faan Jokers__](documentation/bloody30faan.md): Bloody end rules mahjong, with Vietnamese jokers, and somehow more yaku than MCR.
+- [__American (2024 NMJL)__](documentation/american.md): American mahjong. Assemble hands with jokers, and declare other players' hands dead.
 - __Vietnamese__: Mahjong with eight differently powerful joker tiles.
 - __Malaysian__: Three-player mahjong with 16 flowers, a unique joker tile, and instant payouts.
 - __Singaporean__: Mahjong with various instant payouts and various unique ways to get penalized by pao.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ If you're looking to make a custom ruleset using the game's JSON-based ruleset f
 
 ## How can I contribute?
 
-Mostly we need people to play and [report bugs](./issues), of which there are likely many. We also accept pull requests so if you see an [issue](./issues) you'd like to tackle, feel free to do so!
+Mostly we need people to play and [report bugs](https://github.com/EpicOrange/riichi_advanced/issues), of which there are likely many. We also accept pull requests so if you see an [issue](https://github.com/EpicOrange/riichi_advanced/issues) you'd like to tackle, feel free to do so!
 
 Also if you know of any English-based mahjong rulesets available online, do tell us in Discord and we'll add it to the list!
 

--- a/documentation/american.md
+++ b/documentation/american.md
@@ -4,7 +4,7 @@ This documentation file contains the rules of American Mah-Jongg (NMJL-style), a
 
 See also [MahjongPros' ruleset](https://mahjongpros.com/blogs/how-to-play/beginners-guide-to-american-mahjong).
 
-Note that American Mah-Jongg differs from the "base Asian mahjong variant" in many ways, so your knowledge of those variants may not necessarily transfer.
+Note that American Mah-Jongg differs from the "base Asian mahjong variant" presented in [base.md](base.md) in many ways, so your knowledge of those variants may not necessarily transfer. Nevertheless, this ruleset assumes that you have read that one.
 
 ---
 ## TL;DR summary for American Mah-Jongg players:

--- a/documentation/chinitsu_challenge.md
+++ b/documentation/chinitsu_challenge.md
@@ -1,6 +1,6 @@
 # Chinitsu Challenge
 
-Chinitsu Challenge is a variation of Riichi mahjong. Besides having two players instead of four, the core differences are as follows:
+Chinitsu Challenge is a variation of [Riichi mahjong](riichi.md). Besides having two players instead of four, the core differences are as follows:
 
 - Only the 36 souzu tiles are used.
 - Your starting score is 150000 instead of 25000.

--- a/documentation/chinitsu_challenge.md
+++ b/documentation/chinitsu_challenge.md
@@ -6,5 +6,5 @@ Chinitsu Challenge is a variation of [Riichi mahjong](riichi.md). Besides having
 - Your starting score is 150000 instead of 25000.
 - There is no dead wall or dora indicator.
 - Calling chii, pon, and kan (other than ankan) are disallowed. The replacement draw on an ankan is drawn from the front of the wall.
-- Riichi costs 0. There is no honba.
+- Riichi costs 0. There is no honba. There are no tenpai/noten payments.
 - The game will allow you to chombo (e.g. by declaring Riichi when you aren't in riichi, or declaring a false win or a win while in furiten). This comes with a yakuman penalty.

--- a/documentation/chinitsu_challenge.md
+++ b/documentation/chinitsu_challenge.md
@@ -1,0 +1,10 @@
+# Chinitsu Challenge
+
+Chinitsu Challenge is a variation of Riichi mahjong. Besides having two players instead of four, the core differences are as follows:
+
+- Only the 36 souzu tiles are used.
+- Your starting score is 150000 instead of 25000.
+- There is no dead wall or dora indicator.
+- Calling chii, pon, and kan (other than ankan) are disallowed. The replacement draw on an ankan is drawn from the front of the wall.
+- Riichi costs 0. There is no honba.
+- The game will allow you to chombo (e.g. by declaring Riichi when you aren't in riichi, or declaring a false win or a win while in furiten). This comes with a yakuman penalty.

--- a/documentation/hk.md
+++ b/documentation/hk.md
@@ -1,5 +1,7 @@
 # Hong Kong Old Style (HKOS)
 
+This ruleset assumes that you have read [base.md](base.md).
+
 The wall for HKOS consists of the 1-9 character tiles, 1-9 circle tiles, 1-9 bamboo tiles, the four wind tiles, the three dragon tiles, the four flower tiles, and the four season tiles.
 
 To win, you must achieve one of the following:

--- a/documentation/kansai.md
+++ b/documentation/kansai.md
@@ -1,5 +1,5 @@
 # TODO: Kansai Sanma
 
-Kansai Sanma is a variation of Sanma mostly played in the Kansai region of Japan. The rule changes to sanma are the following:
+Kansai Sanma is a variation of sanma mostly played in the Kansai region of Japan. The rule changes to [sanma](sanma.md) are the following:
 
 TODO

--- a/documentation/sanma.md
+++ b/documentation/sanma.md
@@ -1,6 +1,6 @@
 # Sanma
 
-Sanma, or three-player mahjong, is a variation of Riichi mahjong. Besides having three players instead of four, the core differences are as follows:
+Sanma, or three-player mahjong, is a variation of [Riichi mahjong](riichi.md). Besides having three players instead of four, the core differences are as follows:
 
 - Your starting score is 35000 instead of 25000.
 - Calling chii is disallowed.

--- a/lib/riichi_advanced/game/mod_loader.ex
+++ b/lib/riichi_advanced/game/mod_loader.ex
@@ -60,6 +60,7 @@ defmodule RiichiAdvanced.ModLoader do
     },
     "nojokersmahjongleague" => %{
       display_name: "No Jokers Mahjong League 2024",
+      tutorial_link: "https://docs.google.com/document/d/1APpd-YBnsKKssGmyLQiCp90Wk-06SlIScV1sKpJUbQo/edit?usp=sharing",
       ruleset: "riichi",
       mods: ["nojokersmahjongleague", "kiriage_mangan", "agarirenchan", "tenpairenchan", "dora", "ura", "kandora", "yaku/ippatsu", "tobi", "immediate_kan_dora", "head_bump", "no_double_yakuman"],
       default_mods: ["show_waits"],
@@ -80,6 +81,7 @@ defmodule RiichiAdvanced.ModLoader do
     },
     "chinitsu" => %{
       display_name: "Chinitsu Challenge",
+      tutorial_link: "https://github.com/EpicOrange/riichi_advanced/blob/main/documentation/chinitsu_challenge.md",
       ruleset: "riichi",
       mods: ["chinitsu_challenge"],
       default_mods: ["chombo", "tobi", "yaku/renhou_yakuman", "no_honors"],


### PR DESCRIPTION
Added crossref links between rulesets, largely towards `base.md`.

Added Chinitsu Challenge rules documentation.

(more rulesets for #46 (it never ends))