### PR TITLE
Prettified Three Dead Hands draw.

### DIFF
--- a/priv/static/rulesets/american.json
+++ b/priv/static/rulesets/american.json
@@ -636,7 +636,7 @@
           ["set_status", "dead_hand"],
           ["advance_turn"]
         ]],
-        ["when", [{"name": "toimen_status", "opts": ["dead_hand"]}, {"name": "kamicha_status", "opts": ["dead_hand"]}], [["abortive_draw", "three_dead_hands"]]]
+        ["when", [{"name": "toimen_status", "opts": ["dead_hand"]}, {"name": "kamicha_status", "opts": ["dead_hand"]}], [["pause", 1000], ["ryuukyoku", "Three Dead Hands"]]]
       ],
       "unskippable": true
     },
@@ -658,7 +658,7 @@
           ["set_status", "dead_hand"],
           ["advance_turn"]
         ]],
-        ["when", [{"name": "shimocha_status", "opts": ["dead_hand"]}, {"name": "kamicha_status", "opts": ["dead_hand"]}], [["abortive_draw", "three_dead_hands"]]]
+        ["when", [{"name": "shimocha_status", "opts": ["dead_hand"]}, {"name": "kamicha_status", "opts": ["dead_hand"]}], [["pause", 1000], ["ryuukyoku", "Three Dead Hands"]]]
       ],
       "unskippable": true
     },
@@ -680,7 +680,7 @@
           ["set_status", "dead_hand"],
           ["advance_turn"]
         ]],
-        ["when", [{"name": "shimocha_status", "opts": ["dead_hand"]}, {"name": "toimen_status", "opts": ["dead_hand"]}], [["abortive_draw", "three_dead_hands"]]]
+        ["when", [{"name": "shimocha_status", "opts": ["dead_hand"]}, {"name": "toimen_status", "opts": ["dead_hand"]}], [["pause", 1000], ["ryuukyoku", "Three Dead Hands"]]]
       ],
       "unskippable": true
     },


### PR DESCRIPTION
Also, this draw is exhaustive, NOT abortive in nature; dealership passes.

(This patch assumes that `["ryuukyoku", "name"]` works.)