### PR TITLE
Fixed some bugs in MCR

### DIFF
--- a/priv/static/rulesets/mcr.json
+++ b/priv/static/rulesets/mcr.json
@@ -508,7 +508,7 @@
     { "display_name": "Exclusionary Rule", "value": -1, "when": [{"name": "has_existing_yaku", "opts": ["Pure Straight", "Pure Double Chow", "Short Straight"]}] }
   ],
   "extra_yaku": [
-    { "display_name": "Flower Tiles", "value": "flower_count", "when": [{"name": "counter_at_least", "opts": ["flower", 1]}]}
+    { "display_name": "Flower Tiles", "value": "flower_count", "when": [{"name": "counter_at_least", "opts": ["flower_count", 1]}]}
   ],
   "yaku_precedence": {
       // <TODO LIST FOR THIS SECTION: everything below `----------` needs first pass, everything below `==========` line needs second pass>

--- a/priv/static/rulesets/mcr.json
+++ b/priv/static/rulesets/mcr.json
@@ -612,7 +612,7 @@
   "score_calculation": {
     "scoring_method": "multiplier",
     "score_multiplier": 1,
-    "discarder_multiplier": 1,
+    "discarder_multiplier": 3, //hotfix due to the hand's score being divided by 3 for some reason; remove when that underlying bug is fixed
     "discarder_penalty": 8,
     "non_discarder_multiplier": 0,
     "non_discarder_penalty": 8,


### PR DESCRIPTION
Fix for #120. Note that this is two separate bugs:

* Flowers not being counted (#120a);
* The hand's score being divided by 3 for some reason when computing the discarder's payment (#120b)

#120a should be properly fixed. #120b is a bodge-fix, in that I don't understand the underlying cause, and have decided to multiply the discarder's payment by 3 instead. If the underlying cause is fixed, the bodge-fix here will have to be undone.