### PR TITLE
Riichi autodiscard fix (again)

### DIFF
--- a/priv/static/mods/yaku/riichi.majs
+++ b/priv/static/mods/yaku/riichi.majs
@@ -56,8 +56,11 @@ apply prepend, "functions.discard_passed" do
 end
 
 on before_call, prepend: true do
+  if status("just_reached") do
+    place_riichi_stick
+    enable_auto_button("_4_auto_discard")
+  end
   unset_status("just_reached")
-  enable_auto_button("_4_auto_discard")
 end
 
 def place_riichi_stick do


### PR DESCRIPTION
Previous fix accidentally turned on the auto-discard button after a kan, as well as the auto-discard button if anyone else called a tile from you (regardless of whether it was the riichi tile). Hopefully this should fix that.