### PR TITLE
Replace drop-shadow on tiles with box-shadow

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1454,10 +1454,10 @@ div.tile {
   filter: brightness(var(--tile-brightness)) saturate(var(--tile-saturate));
 }
 div.tile:not(.flat) {
-  padding-top: calc(0.25 * var(--tile-size));
-  filter: drop-shadow(0 calc(var(--tile-height) / -8) 0 var(--tile-front-side))
-          drop-shadow(0 calc(var(--tile-height) / -8) 0 var(--tile-back-side))
-          brightness(var(--tile-brightness)) saturate(var(--tile-saturate));
+  margin-bottom: calc(0.25 * var(--tile-size));
+  box-shadow: inset 0 1px 0 0 var(--tile-front-side),
+              0 calc(var(--tile-height) / -8) 0 0 var(--tile-front-side),
+              0 calc(var(--tile-height) / -4) 0 0 var(--tile-back-side);
 }
 div.hand.self div.tiles > div.tile.selected,
 div.hand.self div.draws > div.tile.selected {
@@ -1476,31 +1476,31 @@ div.hand.self div.draws > div.tile.selected::before {
   bottom: calc(-0.25 * var(--tile-size));
 }
 div.tile.sideways:not(.flat) {
-  filter: drop-shadow(0 calc(var(--tile-height) / -16) 0 var(--tile-front-side))
-          drop-shadow(0 calc(var(--tile-height) / -8) 0 var(--tile-back-side))
-          brightness(var(--tile-brightness)) saturate(var(--tile-saturate));
+  box-shadow: inset 0 1px 0 0 var(--tile-front-side),
+              0 calc(var(--tile-height) / -16) 0 0 var(--tile-front-side),
+              0 calc(var(--tile-height) / -8) 0 0 var(--tile-back-side);
 }
 div.pond.self div.tile:not(.flat),
 div.self div.flowers div.tile:not(.flat) {
-  filter: drop-shadow(0 calc(var(--tile-height) / 8) 0 var(--tile-front-side))
-          drop-shadow(0 calc(var(--tile-height) / 8) 0 var(--tile-back-side))
-          brightness(var(--tile-brightness)) saturate(var(--tile-saturate));
+  box-shadow: inset 0 -1px 0 0 var(--tile-front-side),
+              0 calc(var(--tile-height) / 8) 0 0 var(--tile-front-side),
+              0 calc(var(--tile-height) / 4) 0 0 var(--tile-back-side);
 }
 div.shimocha div.tile:not(.flat) {
-  filter: drop-shadow(calc(var(--tile-height) / -8) 0 0 var(--tile-front-side))
-          drop-shadow(calc(var(--tile-height) / -8) 0 0 var(--tile-back-side))
-          brightness(var(--tile-brightness)) saturate(var(--tile-saturate));
+  box-shadow: inset 1px 0 0 0 var(--tile-front-side),
+              calc(var(--tile-height) / -8) 0 0 0 var(--tile-front-side),
+              calc(var(--tile-height) / -4) 0 0 0 var(--tile-back-side);
 }
 div.kamicha div.tile:not(.flat) {
-  filter: drop-shadow(calc(var(--tile-height) / 8) 0 0 var(--tile-front-side))
-          drop-shadow(calc(var(--tile-height) / 8) 0 0 var(--tile-back-side))
-          brightness(var(--tile-brightness)) saturate(var(--tile-saturate));
+  box-shadow: inset -1px 0 0 0 var(--tile-front-side),
+              calc(var(--tile-height) / 8) 0 0 0 var(--tile-front-side),
+              calc(var(--tile-height) / 4) 0 0 0 var(--tile-back-side);
 }
 div.tile.reversed:not(.flat) {
   transform: scaleX(-100%) translateY(calc(var(--tile-height) / -4)) translateZ(0);
-  filter: drop-shadow(0 calc(var(--tile-height) / 8) 0 var(--tile-front-side))
-          drop-shadow(0 calc(var(--tile-height) / 8) 0 var(--tile-back-side))
-          brightness(var(--tile-brightness)) saturate(var(--tile-saturate));
+  box-shadow: inset 0 -1px 0 0 var(--tile-front-side),
+              0 calc(var(--tile-height) / 8) 0 0 var(--tile-front-side),
+              0 calc(var(--tile-height) / 4) 0 0 var(--tile-back-side);
 }
 div.pond.self div.tile.reversed:not(.flat) {
   transform: scaleX(-100%) translateY(calc(var(--tile-height) / -4)) translateZ(0);
@@ -1575,35 +1575,35 @@ div.self div.tile:nth-child(30) { z-index: 29; }
 
 /* all 3d effects should have reversed color for upside down tiles */
 div.tile.\31 x:not(.flat) {
-  filter: drop-shadow(0 calc(var(--tile-height) / -8) 0 var(--tile-back-side))
-          drop-shadow(0 calc(var(--tile-height) / -8) 0 var(--tile-front-side))
-          brightness(var(--tile-brightness)) saturate(var(--tile-saturate));
+  box-shadow: inset 0 1px 0 0 var(--tile-back-side),
+              0 calc(var(--tile-height) / -8) 0 0 var(--tile-back-side),
+              0 calc(var(--tile-height) / -4) 0 0 var(--tile-front-side);
 }
 div.tile.\31 x.sideways:not(.flat) {
-  filter: drop-shadow(0 calc(var(--tile-height) / -16) 0 var(--tile-back-side))
-          drop-shadow(0 calc(var(--tile-height) / -8) 0 var(--tile-front-side))
-          brightness(var(--tile-brightness)) saturate(var(--tile-saturate));
+  box-shadow: inset 0 1px 0 0 var(--tile-back-side),
+              0 calc(var(--tile-height) / -16) 0 0 var(--tile-back-side),
+              0 calc(var(--tile-height) / -8) 0 0 var(--tile-front-side);
 }
 div.pond.self div.tile.\31 x:not(.flat) {
-  filter: drop-shadow(0 calc(var(--tile-height) / 8) 0 var(--tile-back-side))
-          drop-shadow(0 calc(var(--tile-height) / 8) 0 var(--tile-front-side))
-          brightness(var(--tile-brightness)) saturate(var(--tile-saturate));
+  box-shadow: inset 0 -1px 0 0 var(--tile-back-side),
+              0 calc(var(--tile-height) / 8) 0 0 var(--tile-back-side),
+              0 calc(var(--tile-height) / 4) 0 0 var(--tile-front-side);
 }
 div.shimocha div.tile.\31 x:not(.flat) {
-  filter: drop-shadow(calc(var(--tile-height) / -8) 0 0 var(--tile-back-side))
-          drop-shadow(calc(var(--tile-height) / -8) 0 0 var(--tile-front-side))
-          brightness(var(--tile-brightness)) saturate(var(--tile-saturate));
+  box-shadow: inset 1px 0 0 0 var(--tile-back-side),
+              calc(var(--tile-height) / -8) 0 0 0 var(--tile-back-side),
+              calc(var(--tile-height) / -4) 0 0 0 var(--tile-front-side);
 }
 div.kamicha div.tile.\31 x:not(.flat) {
-  filter: drop-shadow(calc(var(--tile-height) / 8) 0 0 var(--tile-back-side))
-          drop-shadow(calc(var(--tile-height) / 8) 0 0 var(--tile-front-side))
-          brightness(var(--tile-brightness)) saturate(var(--tile-saturate));
+  box-shadow: inset -1px 0 0 0 var(--tile-back-side),
+              calc(var(--tile-height) / 8) 0 0 0 var(--tile-back-side),
+              calc(var(--tile-height) / 4) 0 0 0 var(--tile-front-side);
 }
 /* facedown tiles in hand should look facedown */
 div.tiles div.tile.facedown:not(.flat) {
-  filter: drop-shadow(0 calc(var(--tile-height) / 8) 0 var(--tile-back-side))
-          drop-shadow(0 calc(var(--tile-height) / 8) 0 var(--tile-front-side))
-          brightness(var(--tile-brightness)) saturate(var(--tile-saturate));
+  box-shadow: inset 0 -1px 0 0 var(--tile-back-side),
+              0 calc(var(--tile-height) / 8) 0 0 var(--tile-back-side),
+              0 calc(var(--tile-height) / 4) 0 0 var(--tile-front-side);
 }
 
 
@@ -1620,6 +1620,7 @@ div.tiles div.tile.facedown:not(.flat) {
 div.tile.removed {
   background: transparent;
   filter: none;
+  box-shadow: none;
   animation: tilePlayed 0.75s ease forwards;
 }
 div.tile.removed ~ div.tile.draw {


### PR DESCRIPTION
On safari, drop shadows on tiles often have rendering issues.

<img width="195" height="106" alt="Screenshot 2026-01-24 at 12 35 05 PM" src="https://github.com/user-attachments/assets/aeb3596d-f864-4ea6-ab1f-e28b17f2cb92" />

This replaces drop-shadow with box-shadow, to produce the same overall effect, but (hopefully) without the rendering issues. Looks okay on Safari/Chrome/Firefox to me on macOS, but would welcome other testing!