### PR TITLE
Joker replacement bodgefix

### DIFF
--- a/lib/riichi_advanced/game/game_state/marking.ex
+++ b/lib/riichi_advanced/game/game_state/marking.ex
@@ -134,12 +134,12 @@ defmodule RiichiAdvanced.GameState.Marking do
           |> Enum.map(fn {_src, mark_info} -> mark_info.marked end)
           |> Enum.concat()
           |> Enum.all?(fn {call, _, _} ->
-              # NOTE: this line might be broken. current fallback is to replace `:"joker"` with `:"1j", :"2y"`.
-            call_tile = Utils.get_joker_meld_tile(call, [:"joker"], state.players[marking_player].tile_behavior)
+              # NOTE: this line is hardcoded to only allow swapping out tiles 1j and 2y. If you need to swap out other jokers, edit this. No, `:"joker"` doesn't work.
+            call_tile = Utils.get_joker_meld_tile(call, [:"1j", :"2y"], state.players[marking_player].tile_behavior)
             Utils.same_tile(tile, Utils.strip_attrs(call_tile), state.players[marking_player].tile_behavior) end)
         "match_call_to_marked_hand" ->
-              # NOTE: this line might be broken. current fallback is to replace `:"joker"` with `:"1j", :"2y"`.
-          call_tile = Utils.get_joker_meld_tile(tile, [:"joker"], state.players[marking_player].tile_behavior)
+              # NOTE: this line is hardcoded to only allow swapping out tiles 1j and 2y. If you need to swap out other jokers, edit this. No, `:"joker"` doesn't work.
+          call_tile = Utils.get_joker_meld_tile(tile, [:"1j", :"2y"], state.players[marking_player].tile_behavior)
           state.marking[marking_player]
           |> Enum.filter(fn {src, _mark_info} -> src == :hand end)
           |> Enum.map(fn {_src, mark_info} -> mark_info.marked end)


### PR DESCRIPTION
Previously, the "Replaceable Fly Joker" mod in Malaysian wasn't working. Turns out, `marking.ex` is hardcoded to only accept joker swaps with the tile `1j`.

I couldn't figure out how to allow swaps with arbitrary jokers (using `joker` doesn't work), so for now I've just hardcoded it to allow both `1j` and `2y`.