### PR TITLE
Fix solver.ex crash on Windows

### DIFF
--- a/lib/ex_smt/solver.ex
+++ b/lib/ex_smt/solver.ex
@@ -52,7 +52,7 @@ defmodule ExSMT.Solver do
   def poll_z3(z3, acc) do
     case ExCmd.Process.read(z3) do
       {:ok, output} ->
-        acc = String.trim_trailing(acc <> "\n" <> output) # support \r\n and \n
+        acc = acc <> "\n" <> String.replace(String.trim_trailing(output), "\r", "") # support \r\n and \n
         if String.ends_with?(acc, @eot) do
           {:ok, String.slice(acc, 0, byte_size(acc) - byte_size(@eot))}
         else


### PR DESCRIPTION
This PR should fix a crash regarding solver.ex on Windows.

I'm hesitant to push directly, because I don't know if this change will break solver.ex on Linux (and because I haven't thoroughly tested to see if it fixes all Windows crashes). Would like some testing before this is accepted.