### PR TITLE
Refactor Golden Chun, add more debug test cases

### DIFF
--- a/lib/riichi_advanced/game/game_state/debug.ex
+++ b/lib/riichi_advanced/game/game_state/debug.ex
@@ -118,10 +118,24 @@ defmodule RiichiAdvanced.GameState.Debug do
     wall
   end
   def set_starting_hand(wall) do
+
+    # 13-tile starting hand
     hands = %{:east  => Enum.slice(wall, 0..12),
               :south => Enum.slice(wall, 13..25),
               :west  => Enum.slice(wall, 26..38),
               :north => Enum.slice(wall, 39..51)}
+
+    # # 12-tile starting hand
+    # hands = %{:east  => Enum.slice(wall, 0..11),
+    #           :south => Enum.slice(wall, 12..23),
+    #           :west  => Enum.slice(wall, 24..35),
+    #           :north => Enum.slice(wall, 36..47)}
+
+    # # 16-tile starting hand
+    # hands = %{:east  => Enum.slice(wall, 0..15),
+    #           :south => Enum.slice(wall, 16..31),
+    #           :west  => Enum.slice(wall, 32..47),
+    #           :north => Enum.slice(wall, 48..63)}
               
     # # random hand 112233577889p with two fly jokers
     # hands = %{:east  => Utils.sort_tiles([:"2y", :"1p", :"1p", :"2p", :"2p", :"3p", :"3p", :"5p", :"7p", :"7p", :"8p", :"2y", :"9p"]),
@@ -543,6 +557,12 @@ defmodule RiichiAdvanced.GameState.Debug do
     #           :south => Enum.slice(wall, 13..25),
     #           :west  => Enum.slice(wall, 26..38),
     #           :north => Enum.slice(wall, 39..51)}
+
+    # golden chun (recommended to set first draw to 5s so that you get a choice between riichi on 7z or 5s)
+    hands = %{:east  => Utils.sort_tiles([:"1s", :"2s", :"3s", :"7s", :"8s", :"9s", :"7m", :"8m", :"9m", :"06z", :"6z", :"7z", :"37z"]),
+              :south => Enum.slice(wall, 13..25),
+              :west  => Enum.slice(wall, 26..38),
+              :north => Enum.slice(wall, 39..51)}
 
     # # FF 11a 33a 55a 55b 77b 99b
     # hands = %{:east  => Utils.sort_tiles([:"1f", :"1g", :"1m", :"1m", :"3m", :"3m", :"5m", :"5m", :"5p", :"5p", :"7p", :"7p", :"9p"]),

--- a/priv/static/mods/golden_chun.jq
+++ b/priv/static/mods/golden_chun.jq
@@ -21,75 +21,38 @@
 # support for star suit mod
 if any(.wall[]; . == "1t") then
   .after_start.actions += [
-    ["set_tile_alias_all", ["37z"], ["5m", "5p", "5s", "5t", "7z"]]
+      # we can use the "_golden" attribute to keep track of when the golden chun is used as a five
+    ["set_tile_alias_all", ["37z"], [["5m", "_golden"], ["5p", "_golden"], ["5s", "_golden"], ["5t", "_golden"], "7z"]]
   ]
 else
   .after_start.actions += [
-    ["set_tile_alias_all", ["37z"], ["5m", "5p", "5s", "7z"]]
+    ["set_tile_alias_all", ["37z"], [["5m", "_golden"], ["5p", "_golden"], ["5s", "_golden"], "7z"]]
   ]
 end
-# add golden chun definition for when it's used as a five
-|
-.golden_chun_77z_win_definition = [
-  [ "exhaustive", [["chun_pair"], 1], [["shuntsu", "koutsu"], 4] ],
-  [ [["chun_pair"], 1], [["pair"], 6] ]
-]
-|
-.golden_chun_777z_win_definition = [
-  [ "debug", "exhaustive", [["chun"], 1], [["pair"], 1], [["shuntsu", "koutsu"], 3] ]
-]
 |
 # add aka and golden chun yaku
 .extra_yaku += [
-  {"display_name": "Kin", "value": 1, "when": [
-    {"name": "status", "opts": ["golden_chun"]},
-    [
-      {"name": "status_missing", "opts": ["7z"]},
-      [
-        {"name": "status", "opts": ["77z"]},
-        {"name": "match", "opts": [["hand", "calls", "winning_tile"], ["golden_chun_77z_win"]]}
-      ],
-      [
-        {"name": "status", "opts": ["777z"]},
-        {"name": "match", "opts": [["hand", "calls", "winning_tile"], ["golden_chun_777z_win"]]}
-      ]
-    ]
-  ]}
+  {"display_name": "Kin", "value": "golden_chuns", "when": [{"name": "counter_at_least", "opts": ["golden_chuns", 1]}]}
 ]
 |
-# count aka and add golden chun statuses
+# add akahatsu to counter. add aka_h status
 .before_win.actions += [
-  ["when", [{"name": "match", "opts": [["hand", "calls", "winning_tile"], [[ "nojoker", [["06z"], 1] ]]]}], [["add_counter", "aka", 1]]],
-  ["when", [{"name": "match", "opts": [["hand", "calls", "winning_tile"], [[ "nojoker", [["37z"], 1] ]]]}], [["set_status", "golden_chun"]]],
-  ["when", [{"name": "match", "opts": [["hand", "calls", "winning_tile"], [[ "nojoker", [["37z"], 1], [["7z"], 1] ]]]}], [["set_status", "7z"]]],
-  ["when", [{"name": "match", "opts": [["hand", "calls", "winning_tile"], [[ "nojoker", [["37z"], 1], [["chun_pair"], 1] ]]]}], [["set_status", "77z"]]],
-  ["when", [{"name": "match", "opts": [["hand", "calls", "winning_tile"], [[ "nojoker", [["37z"], 1], [["chun"], 1] ]]]}], [["set_status", "777z"]]]
+  ["add_counter", "aka", "count_matches", ["hand", "calls", "winning_tile"], [["nojoker", [["06z"], 1] ]]],
+  ["when", [{"name": "match", "opts": [["hand", "calls", "winning_tile"], [["nojoker", [["06z"], 1] ]]]}], [["set_status", "aka_h"]]]      
 ]
 |
-.after_win.actions += [
-  ["when", [
-    {"name": "status", "opts": ["golden_chun"]},
-    [
-      {"name": "status_missing", "opts": ["7z"]},
-      [
-        {"name": "status", "opts": ["77z"]},
-        {"name": "match", "opts": [["assigned_hand", "assigned_calls", "winning_tile"], ["golden_chun_77z_win"]]}
-      ],
-      [
-        {"name": "status", "opts": ["777z"]},
-        {"name": "match", "opts": [["assigned_hand", "assigned_calls", "winning_tile"], ["golden_chun_777z_win"]]}
-      ]
-    ]
-  ], [["set_status", "kindora"]]]
+# add golden chun status
+.before_scoring.actions += [
+  ["add_counter", "golden_chuns", "count_matches", ["hand", "calls", "winning_tile"], [[[[{"tile": "any", "attrs": ["golden"]}], 1]]]],
+  ["when", [{"name": "match", "opts": [["hand", "calls", "winning_tile"], [[[[{"tile": "any", "attrs": ["golden"]}], 1]]]]}], [["set_status", "golden_chun"]]]
 ]
 |
-# add golden chun yakuman
+# add sangen pocchi yakuman
 .yakuman += [
-  {"display_name": "Sangen Pocchi", "value": 1, "when": [{"name": "status", "opts": ["shiro_pocchi", "aka_h", "kindora"]}]}
+  {"display_name": "Sangen Pocchi", "value": 1, "when": [{"name": "status", "opts": ["shiro_pocchi", "aka_h", "golden_chun"]}]}
 ]
 |
 # can't call golden chun unless as a chun
-
 if (.buttons | has("chii")) then
   .buttons.chii.call_conditions += [[
     {"name": "not_call_contains", "opts": [["37z"], 1]},

--- a/priv/static/rulesets/riichi.majs
+++ b/priv/static/rulesets/riichi.majs
@@ -503,6 +503,10 @@ on before_call do
 end
 
 on before_win do
+  noop
+end
+
+on before_scoring do
   add_scoring_attrs
   calculate_fu
 end


### PR DESCRIPTION
This PR refactors `golden_chun.jq` using tile attributes. In particular, this also fixes the following bugs:

* Golden Chun did not previously correctly detect when the golden chun was used as a 5. This caused the "Kin" yaku and "Sangen Pocchi" yakuman to not be awarded properly. Using tile attributes, this is now correctly-detected.

* Fu was not being counted correctly whenever the golden chun was used as a 5. This is now fixed by making scoring attributes/fu be assigned/counted during `before_scoring` instead of `before_win`, in `riichi.majs`. I checked and fu appears to be correctly-counted in other Riichi variants as well, so this shouldn't break anything.

I also added the following debug cases:

* A debug case for Golden Chun that gives the player the option to use the golden chun as either a 7z or a 5s.

* Debug cases for Shouhai and Taiwanese, since the default debug case forces hands to be 13 tiles long.